### PR TITLE
feat: add band page

### DIFF
--- a/BAND_PAGE_FEATURE.md
+++ b/BAND_PAGE_FEATURE.md
@@ -1,0 +1,171 @@
+# Band Page Feature Implementation
+
+## Overview
+
+Implemented a comprehensive band page feature that displays detailed information about bands in a modal dialog. Band pages can be accessed either by clicking on band names in festival cards or by navigating directly to `/bands/{band-key}` URLs.
+
+## Features Implemented
+
+### 1. Band Modal Component (`css/band-modal.css`)
+
+- Responsive modal overlay with smooth animations
+- Professional dark theme matching the site design
+- Displays:
+  - Band logo (centered at top)
+  - Band name with country
+  - Headline image
+  - Description
+  - Genres (styled tags)
+  - Band members (grid layout)
+  - Action buttons for Official Website and Spotify
+
+### 2. Band Manager (`js/band-manager.js`)
+
+- Loads band data from `db.json`
+- Validates if bands have complete information
+- Creates and manages modal display
+- Handles URL routing for band pages
+- Supports both modal and standalone page modes
+- Browser back/forward button support
+- ESC key to close modal
+
+### 3. Clickable Band Tags
+
+- Band names in festival cards are now clickable if they have complete information in the database
+- Hover effect with info icon (ℹ)
+- Visual feedback on hover
+- Only bands with complete data (logo, description, genres, members, etc.) are clickable
+
+### 4. URL Routing Integration
+
+- Direct navigation to `/bands/{band-key}` opens standalone band page
+- Modal opening updates URL without page reload
+- Closing modal restores previous URL
+- Full browser history support
+
+### 5. Standalone Band Pages
+
+- When accessing `/bands/{band-key}` directly:
+  - Full page with header and footer
+  - Centered modal-style content
+  - Same styling as modal version
+  - 404 handling for non-existent bands
+
+## Files Modified/Created
+
+### New Files
+
+- `/css/band-modal.css` - Complete styling for band modal and pages
+- `/js/band-manager.js` - Band data management and modal logic
+
+### Modified Files
+
+- `/index.html` - Added band-modal.css and band-manager.js
+- `/map.html` - Added band-modal.css and band-manager.js
+- `/script.js` - Integrated BandManager, made band tags clickable
+- `/js/map.js` - Integrated BandManager in map view
+- `/js/router.js` - Added support for `/bands/{key}` routes
+
+## Usage
+
+### For Users
+
+1. **From Timeline/Map**: Click on any highlighted band name to view details
+2. **Direct Link**: Navigate to `/bands/within-temptation` or `/bands/in-flames`
+3. **Close Modal**: Click X button, press ESC, or click outside modal
+
+### For Developers
+
+#### Adding New Bands to Database
+
+```json
+{
+  "bands": [
+    {
+      "key": "band-name-slug",
+      "name": "Band Name",
+      "country": "Country",
+      "description": "Full description...",
+      "headlineImage": "URL to band photo",
+      "logo": "URL to band logo",
+      "website": "Official website URL",
+      "spotify": "Spotify artist URL",
+      "genres": ["Genre 1", "Genre 2"],
+      "members": [
+        {
+          "name": "Member Name",
+          "role": "Instrument/Role"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Required Fields for Clickable Band Links
+
+All fields must be present and non-empty:
+
+- `key` (URL-safe slug)
+- `name`
+- `description`
+- `logo`
+- `headlineImage`
+- `website`
+- `spotify`
+- `genres` (array with at least one item)
+- `members` (array with at least one member)
+
+## Styling Details
+
+### Color Scheme
+
+- Primary: `#ff6b00` (orange)
+- Background: Dark gradients (`#1a1a1a` to `#2d2d2d`)
+- Text: `#fff` (white) and `#ccc` (gray)
+- Accents: `rgba(255, 107, 0, 0.x)` for transparency effects
+
+### Responsive Design
+
+- Desktop: Max-width 800px modal
+- Mobile: Full-width with adjusted padding
+- Touch-friendly buttons and interactive elements
+- Optimized layouts for small screens
+
+### Animations
+
+- Fade-in overlay (0.3s)
+- Scale-up modal (0.3s)
+- Smooth transitions on hover
+- Rotate effect on close button hover
+
+## Browser Compatibility
+
+- Modern browsers with ES6+ support
+- CSS Grid and Flexbox
+- History API for routing
+- No external dependencies (pure vanilla JS)
+
+## Testing Checklist
+
+- ✅ Click band name in timeline → modal opens
+- ✅ Click band name in map → modal opens
+- ✅ Direct URL `/bands/within-temptation` → standalone page
+- ✅ Direct URL `/bands/in-flames` → standalone page
+- ✅ Modal close button works
+- ✅ ESC key closes modal
+- ✅ Click outside modal closes it
+- ✅ URL updates when modal opens
+- ✅ Browser back button works
+- ✅ Only complete bands are clickable
+- ✅ Responsive on mobile devices
+- ✅ All links work (website, Spotify)
+
+## Future Enhancements
+
+- Add more bands to database
+- Implement band search functionality
+- Add social media links
+- Include discography information
+- Add similar bands recommendations
+- Implement band filtering in timeline/map by genre

--- a/css/band-modal.css
+++ b/css/band-modal.css
@@ -1,0 +1,323 @@
+/* Band Modal Styles */
+
+.band-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 85%);
+  backdrop-filter: blur(5px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+  padding: 2rem;
+  overflow-y: auto;
+}
+
+.band-modal-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.band-modal {
+  background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+  border: 2px solid #ff6b00;
+  border-radius: 15px;
+  max-width: 800px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 50px rgb(255 107 0 / 30%);
+  transform: scale(0.9);
+  transition: transform 0.3s ease;
+  position: relative;
+}
+
+.band-modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgb(255 107 0 / 20%);
+  border: 2px solid #ff6b00;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #ff6b00;
+  font-size: 1.5rem;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  z-index: 10;
+}
+
+.band-modal-close:hover {
+  background: #ff6b00;
+  color: #1a1a1a;
+  transform: rotate(90deg);
+}
+
+/* Standalone band page */
+.standalone-band-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding-top: 80px;
+}
+
+.standalone-band-page .band-modal-overlay {
+  position: relative;
+  height: auto;
+  min-height: calc(100vh - 80px);
+  opacity: 1;
+  visibility: visible;
+  background-color: transparent;
+  backdrop-filter: none;
+  padding: 2rem 1rem;
+}
+
+.standalone-band-page .band-modal {
+  margin: 0 auto;
+  transform: scale(1);
+}
+
+.standalone-band-page .band-modal-close {
+  display: none;
+}
+
+.band-modal-overlay.active .band-modal {
+  transform: scale(1);
+}
+
+.band-modal-header {
+  text-align: center;
+  padding: 2rem;
+  background: linear-gradient(180deg, rgb(255 107 0 / 10%) 0%, transparent 100%);
+  border-bottom: 1px solid rgb(255 107 0 / 20%);
+}
+
+.band-modal-logo {
+  max-width: 300px;
+  max-height: 80px;
+  margin: 0 auto 1rem;
+  display: block;
+  object-fit: contain;
+}
+
+.band-modal-name {
+  font-size: 2.5rem;
+  color: #ff6b00;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  text-shadow: 0 0 10px rgb(255 107 0 / 50%);
+}
+
+.band-modal-country {
+  font-size: 1rem;
+  color: #888;
+  margin-top: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.band-modal-content {
+  padding: 2rem;
+}
+
+.band-modal-headline-image {
+  width: 100%;
+  height: 300px;
+  object-fit: cover;
+  border-radius: 10px;
+  margin-bottom: 2rem;
+  border: 2px solid rgb(255 107 0 / 30%);
+}
+
+.band-modal-section {
+  margin-bottom: 2rem;
+}
+
+.band-modal-section h3 {
+  color: #ff6b00;
+  font-size: 1.3rem;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border-bottom: 2px solid rgb(255 107 0 / 30%);
+  padding-bottom: 0.5rem;
+}
+
+.band-modal-description {
+  color: #ccc;
+  line-height: 1.8;
+  font-size: 1rem;
+  text-align: justify;
+}
+
+.band-modal-genres {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.band-modal-genre-tag {
+  background: linear-gradient(135deg, rgb(255 107 0 / 20%) 0%, rgb(255 107 0 / 10%) 100%);
+  border: 1px solid #ff6b00;
+  color: #ff6b00;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.band-modal-members {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.band-modal-member {
+  background: rgb(255 107 0 / 5%);
+  border: 1px solid rgb(255 107 0 / 20%);
+  border-radius: 8px;
+  padding: 1rem;
+  transition: all 0.3s ease;
+}
+
+.band-modal-member:hover {
+  background: rgb(255 107 0 / 10%);
+  border-color: #ff6b00;
+  transform: translateY(-2px);
+}
+
+.band-modal-member-name {
+  color: white;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  font-size: 1rem;
+}
+
+.band-modal-member-role {
+  color: #888;
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.band-modal-actions {
+  display: flex;
+  gap: 1rem;
+  padding: 2rem;
+  background: linear-gradient(180deg, transparent 0%, rgb(255 107 0 / 5%) 100%);
+  border-top: 1px solid rgb(255 107 0 / 20%);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.band-modal-button {
+  background: linear-gradient(135deg, #ff6b00 0%, #ff8533 100%);
+  color: white;
+  border: none;
+  padding: 1rem 2rem;
+  border-radius: 25px;
+  font-size: 1rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  box-shadow: 0 4px 15px rgb(255 107 0 / 30%);
+}
+
+.band-modal-button:hover {
+  background: linear-gradient(135deg, #ff8533 0%, #fa6 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgb(255 107 0 / 40%);
+}
+
+.band-modal-button svg {
+  width: 20px;
+  height: 20px;
+  fill: currentcolor;
+}
+
+/* Clickable band tags in festival cards */
+.band-tag.clickable {
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.band-tag.clickable:hover {
+  background: linear-gradient(135deg, #ff6b00 0%, #ff8533 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgb(255 107 0 / 40%);
+}
+
+.band-tag.clickable::after {
+  content: "ℹ";
+  position: absolute;
+  right: 0.5rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  font-size: 0.8rem;
+}
+
+.band-tag.clickable:hover::after {
+  opacity: 1;
+}
+
+/* Responsive design */
+@media (width <= 768px) {
+  .band-modal-overlay {
+    padding: 1rem;
+  }
+
+  .band-modal {
+    max-height: 95vh;
+  }
+
+  .band-modal-name {
+    font-size: 1.8rem;
+  }
+
+  .band-modal-logo {
+    max-width: 200px;
+    max-height: 60px;
+  }
+
+  .band-modal-headline-image {
+    height: 200px;
+  }
+
+  .band-modal-content {
+    padding: 1rem;
+  }
+
+  .band-modal-actions {
+    padding: 1rem;
+    flex-direction: column;
+  }
+
+  .band-modal-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .band-modal-members {
+    grid-template-columns: 1fr;
+  }
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -33,6 +33,16 @@
   white-space: nowrap;
 }
 
+.header-left h1 a {
+  color: inherit;
+  text-decoration: none;
+  transition: opacity 0.3s ease;
+}
+
+.header-left h1 a:hover {
+  opacity: 0.8;
+}
+
 /* Hamburger Menu */
 .hamburger-menu {
   background: none;

--- a/error.html
+++ b/error.html
@@ -16,7 +16,7 @@
     <header class="header">
         <div class="header-content">
             <div class="header-left">
-                <h1>Metal Festivals 2026</h1>
+                <h1><a href="/">Metal Festivals 2026</a></h1>
             </div>
             <div class="header-right">
                 <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle menu">

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/layout.css">
     <link rel="stylesheet" href="css/components.css">
+    <link rel="stylesheet" href="css/band-modal.css">
     <link rel="stylesheet" href="css/responsive.css">
     <link rel="icon" type="image/png" href="img/metal-fests.png">
 </head>
@@ -21,7 +22,7 @@
     <header class="header">
         <div class="header-content">
             <div class="header-left">
-                <h1>Metal Festivals 2026</h1>
+                <h1><a href="/">Metal Festivals 2026</a></h1>
             </div>
             <div class="header-right">
                 <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle menu">
@@ -72,6 +73,7 @@
     <script src="js/favorites-manager.js"></script>
     <script src="js/filter-manager.js"></script>
     <script src="js/bands-filter-manager.js"></script>
+    <script src="js/band-manager.js"></script>
     <script src="js/ui-utils.js"></script>
     <script src="script.js"></script>
 </body>

--- a/js/band-manager.js
+++ b/js/band-manager.js
@@ -1,0 +1,295 @@
+// Band Manager - handles band modal display and routing
+class BandManager {
+  constructor() {
+    this.bands = [];
+    this.currentBand = null;
+    this.modalOverlay = null;
+    this.isStandalone = false;
+  }
+
+  async loadBands() {
+    try {
+      const response = await fetch("/db.json");
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+      this.bands = data.bands || [];
+      return this.bands;
+    } catch (error) {
+      console.error("Error loading bands:", error);
+      return [];
+    }
+  }
+
+  getBandByKey(key) {
+    return this.bands.find((band) => band.key === key);
+  }
+
+  getBandByName(name) {
+    // Normalize the name for comparison
+    const normalizedName = name.toLowerCase().trim();
+    return this.bands.find((band) => band.name.toLowerCase() === normalizedName);
+  }
+
+  hasCompleteInfo(bandName) {
+    const band = this.getBandByName(bandName);
+    if (!band) return false;
+
+    // Check if band has all required fields
+    return (
+      band.key &&
+      band.name &&
+      band.description &&
+      band.logo &&
+      band.headlineImage &&
+      band.website &&
+      band.spotify &&
+      band.genres &&
+      band.genres.length > 0 &&
+      band.members &&
+      band.members.length > 0
+    );
+  }
+
+  createModal() {
+    // Remove existing modal if any
+    if (this.modalOverlay) {
+      this.modalOverlay.remove();
+    }
+
+    this.modalOverlay = document.createElement("div");
+    this.modalOverlay.className = "band-modal-overlay";
+    this.modalOverlay.innerHTML = `
+      <div class="band-modal">
+        <button class="band-modal-close" aria-label="Close band details">×</button>
+        <div class="band-modal-header">
+          <img src="" alt="" class="band-modal-logo">
+          <h2 class="band-modal-name"></h2>
+          <p class="band-modal-country"></p>
+        </div>
+        <div class="band-modal-content">
+          <img src="" alt="" class="band-modal-headline-image">
+          <div class="band-modal-section">
+            <h3>About</h3>
+            <p class="band-modal-description"></p>
+          </div>
+          <div class="band-modal-section">
+            <h3>Genres</h3>
+            <div class="band-modal-genres"></div>
+          </div>
+          <div class="band-modal-section">
+            <h3>Members</h3>
+            <div class="band-modal-members"></div>
+          </div>
+        </div>
+        <div class="band-modal-actions">
+          <a href="" target="_blank" rel="noopener noreferrer" class="band-modal-button">
+            <svg viewBox="0 0 24 24">
+              <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm-1 5v10h2V7h-2zm0-3v2h2V4h-2z"/>
+            </svg>
+            Official Website
+          </a>
+          <a href="" target="_blank" rel="noopener noreferrer" class="band-modal-button">
+            <svg viewBox="0 0 24 24">
+              <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+            </svg>
+            Listen on Spotify
+          </a>
+        </div>
+      </div>
+    `;
+
+    // Add event listeners
+    const closeButton = this.modalOverlay.querySelector(".band-modal-close");
+    closeButton.addEventListener("click", () => this.closeModal());
+
+    // Close modal when clicking outside
+    this.modalOverlay.addEventListener("click", (e) => {
+      if (e.target === this.modalOverlay) {
+        this.closeModal();
+      }
+    });
+
+    // Close modal on ESC key
+    const escapeHandler = (e) => {
+      if (e.key === "Escape") {
+        this.closeModal();
+        document.removeEventListener("keydown", escapeHandler);
+      }
+    };
+    document.addEventListener("keydown", escapeHandler);
+
+    document.body.appendChild(this.modalOverlay);
+  }
+
+  populateModal(band) {
+    if (!this.modalOverlay) return;
+
+    // Update header
+    const logo = this.modalOverlay.querySelector(".band-modal-logo");
+    logo.src = band.logo;
+    logo.alt = `${band.name} Logo`;
+
+    const name = this.modalOverlay.querySelector(".band-modal-name");
+    name.textContent = band.name;
+
+    const country = this.modalOverlay.querySelector(".band-modal-country");
+    country.textContent = band.country;
+
+    // Update headline image
+    const headlineImage = this.modalOverlay.querySelector(".band-modal-headline-image");
+    headlineImage.src = band.headlineImage;
+    headlineImage.alt = `${band.name} Band Photo`;
+
+    // Update description
+    const description = this.modalOverlay.querySelector(".band-modal-description");
+    description.textContent = band.description;
+
+    // Update genres
+    const genresContainer = this.modalOverlay.querySelector(".band-modal-genres");
+    genresContainer.innerHTML = band.genres
+      .map((genre) => `<span class="band-modal-genre-tag">${genre}</span>`)
+      .join("");
+
+    // Update members
+    const membersContainer = this.modalOverlay.querySelector(".band-modal-members");
+    membersContainer.innerHTML = band.members
+      .map(
+        (member) => `
+      <div class="band-modal-member">
+        <div class="band-modal-member-name">${member.name}</div>
+        <div class="band-modal-member-role">${member.role}</div>
+      </div>
+    `,
+      )
+      .join("");
+
+    // Update action buttons
+    const buttons = this.modalOverlay.querySelectorAll(".band-modal-button");
+    buttons[0].href = band.website;
+    buttons[1].href = band.spotify;
+  }
+
+  showBand(bandKey, isStandalone = false) {
+    this.isStandalone = isStandalone;
+    const band = this.getBandByKey(bandKey);
+
+    if (!band) {
+      console.error(`Band not found: ${bandKey}`);
+      return false;
+    }
+
+    this.currentBand = band;
+    this.createModal();
+    this.populateModal(band);
+
+    // Show modal with animation
+    requestAnimationFrame(() => {
+      this.modalOverlay.classList.add("active");
+    });
+
+    // Update URL if not standalone
+    if (!isStandalone && window.history) {
+      const newUrl = `/bands/${bandKey}`;
+      window.history.pushState({ band: bandKey }, "", newUrl);
+    }
+
+    return true;
+  }
+
+  closeModal() {
+    if (!this.modalOverlay) return;
+
+    this.modalOverlay.classList.remove("active");
+
+    setTimeout(() => {
+      if (this.modalOverlay) {
+        this.modalOverlay.remove();
+        this.modalOverlay = null;
+      }
+    }, 300);
+
+    this.currentBand = null;
+
+    // Update URL back to previous page if not standalone
+    if (!this.isStandalone && window.history) {
+      const currentPath = window.location.pathname;
+      if (currentPath.startsWith("/bands/")) {
+        window.history.back();
+      }
+    }
+  }
+
+  // Create standalone band page
+  createStandalonePage(bandKey) {
+    const band = this.getBandByKey(bandKey);
+
+    if (!band) {
+      // Show 404 error
+      document.body.innerHTML = `
+        <header class="header">
+          <div class="header-content">
+            <div class="header-left">
+              <h1>Metal Festivals 2026</h1>
+            </div>
+          </div>
+        </header>
+        <main class="standalone-band-page">
+          <div style="text-align: center; padding: 4rem; color: #ff4444;">
+            <h2>Band Not Found</h2>
+            <p>The band you're looking for doesn't exist in our database.</p>
+            <a href="/" style="color: #ff6b00; text-decoration: underline;">Return to Timeline</a>
+          </div>
+        </main>
+        <footer>
+          <p>Made with ❤️ by <em>Camaradas del Metal Candente</em> @ 2025</p>
+        </footer>
+      `;
+      return;
+    }
+
+    // Create standalone page structure
+    document.body.className = "standalone-band-page";
+
+    const main = document.querySelector("main");
+    if (main) {
+      main.innerHTML = "";
+      main.className = "standalone-band-page";
+
+      this.createModal();
+      this.populateModal(band);
+      this.modalOverlay.classList.add("active");
+
+      main.appendChild(this.modalOverlay);
+    }
+  }
+
+  // Initialize band manager
+  async init() {
+    await this.loadBands();
+
+    // Check if we're on a band page
+    const path = window.location.pathname;
+    const bandMatch = path.match(/^\/bands\/([a-z0-9-]+)$/);
+
+    if (bandMatch) {
+      const bandKey = bandMatch[1];
+      this.createStandalonePage(bandKey);
+    }
+
+    // Handle popstate for browser back/forward buttons
+    window.addEventListener("popstate", (e) => {
+      if (e.state && e.state.band) {
+        this.showBand(e.state.band, false);
+      } else if (this.currentBand && !this.isStandalone) {
+        this.closeModal();
+      }
+    });
+  }
+}
+
+// Export for use in other modules
+if (typeof window !== "undefined") {
+  window.BandManager = BandManager;
+}

--- a/js/router.js
+++ b/js/router.js
@@ -7,6 +7,7 @@ class ClientRouter {
       "/map": "map.html",
       "/error": "error.html",
     };
+    this.bandRoutePattern = /^\/bands\/([a-z0-9-]+)$/;
     this.init();
   }
 
@@ -53,6 +54,19 @@ class ClientRouter {
 
   handleInitialRoute() {
     const currentPath = window.location.pathname;
+
+    // Check if it's a band route
+    const bandMatch = currentPath.match(this.bandRoutePattern);
+    if (bandMatch) {
+      // Band routes are handled by BandManager in script.js
+      // Just ensure we're on the index page
+      const currentFile = window.location.pathname.split("/").pop();
+      if (currentFile !== "" && currentFile.endsWith(".html") && currentFile !== "index.html") {
+        this.loadPage("index.html");
+      }
+      return;
+    }
+
     const targetPage = this.routes[currentPath];
 
     // Determine the current page for navigation highlighting

--- a/map.html
+++ b/map.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/layout.css">
     <link rel="stylesheet" href="css/components.css">
+    <link rel="stylesheet" href="css/band-modal.css">
     <link rel="stylesheet" href="css/responsive.css">
     <link rel="stylesheet" href="css/map.css">
     <link rel="icon" type="image/png" href="img/metal-fests.png">
@@ -23,7 +24,7 @@
     <header class="header">
         <div class="header-content">
             <div class="header-left">
-                <h1>Metal Festivals 2026</h1>
+                <h1><a href="/">Metal Festivals 2026</a></h1>
             </div>
             <div class="header-right">
                 <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle menu">
@@ -87,6 +88,7 @@
     <script src="js/favorites-manager.js"></script>
     <script src="js/filter-manager.js"></script>
     <script src="js/bands-filter-manager.js"></script>
+    <script src="js/band-manager.js"></script>
     <script src="js/ui-utils.js"></script>
     <script src="js/map.js"></script>
 </body>


### PR DESCRIPTION
This PR adds a new feature to include a bands page as a modal for those bands which we have the full information so it can be represented in the band page.

The required band information is:

- band name and key (`name` needs to be the same than in the festivals list, `key` needs to be url compatible)
- country
- description
- headlineImage url
- logo url
- official website url
- spotify page url
- list of band genres
- list of current band members including their role

Example of the band page:

<img width="1194" height="1646" alt="image" src="https://github.com/user-attachments/assets/14a12344-1b13-4856-89f9-f82f15213750" />

Closes #10 